### PR TITLE
[sinatra-contrib] README: use the full url in link

### DIFF
--- a/sinatra-contrib/README.md
+++ b/sinatra-contrib/README.md
@@ -162,7 +162,7 @@ For more info check the [official docs](http://www.sinatrarb.com/contrib/) and
 [sinatra-webdav]: http://www.sinatrarb.com/contrib/webdav
 [sinatra-runner]: http://www.sinatrarb.com/contrib/runner
 [sinatra-extension]: http://www.sinatrarb.com/contrib/extension
-[sinatra-test-helpers]: http://www.rubydoc.info/github/sinatra/sinatra-contrib/Sinatra/TestHelpers
+[sinatra-test-helpers]: https://github.com/sinatra/sinatra/blob/master/sinatra-contrib/lib/sinatra/test_helpers.rb
 [sinatra-required-params]: http://www.sinatrarb.com/contrib/required_params
 [sinatra-custom-logger]: http://www.sinatrarb.com/contrib/custom_logger
 [sinatra-multi-route]: http://www.sinatrarb.com/contrib/multi_route
@@ -171,5 +171,5 @@ For more info check the [official docs](http://www.sinatrarb.com/contrib/) and
 [sinatra-config-file]: http://www.sinatrarb.com/contrib/config_file
 [sinatra-link-header]: http://www.sinatrarb.com/contrib/link_header
 [sinatra-capture]: http://www.sinatrarb.com/contrib/capture
-[sinatra-engine-tracking]: http://www.rubydoc.info/github/sinatra/sinatra-contrib/Sinatra/EngineTracking
+[sinatra-engine-tracking]: https://github.com/sinatra/sinatra/blob/master/sinatra-contrib/lib/sinatra/engine_tracking.rb
 


### PR DESCRIPTION
This PR applies small changes to PR 1307: uses the full URL in the links to two things (relating to test helpers, engine tracking).

  - see #1307